### PR TITLE
Enable support for iOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 name = "proc_pidinfo"
 path = "src/lib.rs"
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 libc = "0.2"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(
     not(target_os = "macos"),
-    doc = "NOTE: This library is only supported on macOS."
+    doc = "NOTE: This library is only supported on macOS and iOS."
 )]
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub use darwin::*;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 mod darwin;


### PR DESCRIPTION
Although `sys/proc_info.h` is missing on iOS, it seems that all the same facilities are available on iOS.

The following code seems to run and compile just fine on my iPhone 17 device:
<details>
  <summary>Click to expand</summary>

```objc
#import "ViewController.h"

// sys/proc_info.h
extern int proc_pidinfo(int pid, int flavor, uint64_t arg, void *buffer, int buffersize);
extern int proc_pidfdinfo(int pid, int fd, int flavor, void * buffer, int buffersize);

#define PATH_MAX                 1024
#define MAXPATHLEN      PATH_MAX
#define PROX_FDTYPE_VNODE       1
#define PROC_PIDLISTFDS                 1
#define PROC_PIDLISTFD_SIZE             (sizeof(struct proc_fdinfo))
#define PROC_PIDFDVNODEPATHINFO         2
#define PROC_PIDFDVNODEPATHINFO_SIZE    (sizeof(struct vnode_fdinfowithpath))

struct proc_fdinfo {
    int32_t proc_fd;
    uint32_t proc_fdtype;
};

struct proc_fileinfo {
    uint32_t                fi_openflags;
    uint32_t                fi_status;
    off_t                   fi_offset;
    int32_t                 fi_type;
    uint32_t                fi_guardflags;
};

struct vinfo_stat {
    uint32_t        vst_dev;        /* [XSI] ID of device containing file */
    uint16_t        vst_mode;       /* [XSI] Mode of file (see below) */
    uint16_t        vst_nlink;      /* [XSI] Number of hard links */
    uint64_t        vst_ino;        /* [XSI] File serial number */
    uid_t           vst_uid;        /* [XSI] User ID of the file */
    gid_t           vst_gid;        /* [XSI] Group ID of the file */
    int64_t         vst_atime;      /* [XSI] Time of last access */
    int64_t         vst_atimensec;  /* nsec of last access */
    int64_t         vst_mtime;      /* [XSI] Last data modification time */
    int64_t         vst_mtimensec;  /* last data modification nsec */
    int64_t         vst_ctime;      /* [XSI] Time of last status change */
    int64_t         vst_ctimensec;  /* nsec of last status change */
    int64_t         vst_birthtime;  /*  File creation time(birth)  */
    int64_t         vst_birthtimensec;      /* nsec of File creation time */
    off_t           vst_size;       /* [XSI] file size, in bytes */
    int64_t         vst_blocks;     /* [XSI] blocks allocated for file */
    int32_t         vst_blksize;    /* [XSI] optimal blocksize for I/O */
    uint32_t        vst_flags;      /* user defined flags for file */
    uint32_t        vst_gen;        /* file generation number */
    uint32_t        vst_rdev;       /* [XSI] Device ID */
    int64_t         vst_qspare[2];  /* RESERVED: DO NOT USE! */
};

struct vnode_info {
    struct vinfo_stat       vi_stat;
    int                     vi_type;
    int                     vi_pad;
    fsid_t                  vi_fsid;
};

struct vnode_info_path {
    struct vnode_info       vip_vi;
    char                    vip_path[MAXPATHLEN];   /* tail end of it  */
};

struct vnode_fdinfowithpath {
    struct proc_fileinfo    pfi;
    struct vnode_info_path  pvip;
};


@interface ViewController ()

@end

@implementation ViewController

- (void)viewDidLoad {
    [super viewDidLoad];
    // Do any additional setup after loading the view.


    NSString *tempDir = NSTemporaryDirectory();
    NSString *filePath = [tempDir stringByAppendingPathComponent:@"hello-iokit-app.txt"];

    [[NSFileManager defaultManager] createFileAtPath:filePath contents:nil attributes:nil];

    NSFileHandle *fileHandle = [NSFileHandle fileHandleForWritingAtPath:filePath];
    NSLog(@"%@", fileHandle);
    [fileHandle writeData:[@"Hello world!" dataUsingEncoding:NSUTF8StringEncoding]];

    NSLog(@"%@", fileHandle);

    pid_t pid = getpid();

    int bufferSize = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, 0, 0);
    struct proc_fdinfo *procFDInfo = (struct proc_fdinfo *)malloc(bufferSize);

    proc_pidinfo(pid, PROC_PIDLISTFDS, 0, procFDInfo, bufferSize);
    int numberOfProcFDs = bufferSize / PROC_PIDLISTFD_SIZE;

    printf("Found %d fds\n", numberOfProcFDs);

    for(int i = 0; i < numberOfProcFDs; i++) {
        if(procFDInfo[i].proc_fdtype == PROX_FDTYPE_VNODE) {
            printf("[%d] Fd type: %d\n", i, procFDInfo[i].proc_fdtype);

            struct vnode_fdinfowithpath vnodeInfo;
            int bytesUsed = proc_pidfdinfo(pid, procFDInfo[i].proc_fd, PROC_PIDFDVNODEPATHINFO, &vnodeInfo, PROC_PIDFDVNODEPATHINFO_SIZE);
            if (bytesUsed == PROC_PIDFDVNODEPATHINFO_SIZE) {
                printf("Open file: %s\n", vnodeInfo.pvip.vip_path);
            }
        }
    }

    free(procFDInfo);
}


@end
```
</details>

Output:

<details>
  <summary>Click to expand</summary>

```
<NSConcreteFileHandle: 0x301a4c070>
<NSConcreteFileHandle: 0x301a4c070>
Found 70 fds
[0] Fd type: 1
Open file: /dev/null
[1] Fd type: 1
[2] Fd type: 1
[3] Fd type: 1
Open file: /private/var/mobile/Containers/Data/Application/E6E4110C-FF79-4F38-A17C-D405821EF9A2/tmp/hello-iokit-app.txt
```

</details>